### PR TITLE
Change linecolors.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moveroplot"
-version = "1.1.3"
+version = "1.1.4"
 description = "Movero-plot"
 readme = "README.md"
 keywords = [

--- a/src/moveroplot/config/plot_settings.py
+++ b/src/moveroplot/config/plot_settings.py
@@ -1,14 +1,16 @@
 """Static configurations settings for plots."""
 
 modelcolors: list[str] = [
-    "black",
-    "red",
-    "blue",
-    "green",
-    "cyan",
-    "yellow",
-    "magenta",
-    "orange",
+    "tab:red",
+    "tab:blue",
+    "tab:orange",
+    "tab:green",
+    "tab:purple",
+    "tab:brown",
+    "tab:pink",
+    "tab:gray",
+    "tab:olive",
+    "tab:cyan",
 ]
 
 line_styles: list[str] = ["-", ":", "--", "-."]

--- a/src/moveroplot/parse_inputs.py
+++ b/src/moveroplot/parse_inputs.py
@@ -86,6 +86,16 @@ def _parse_inputs(
             """
             )
         plot_settings.modelcolors = color_list
+    else:
+        if len(all_model_versions) > len(plot_settings.modelcolors):
+            raise ValueError(
+                f"""
+            The number of model versions is larger than the
+            number of predefined colors for plotting
+            ({len(all_model_versions)} > {len(plot_settings.modelcolors)})
+            """
+            )
+
     plot_models_setup = [
         model_combinations.split("/")
         for model_combinations in model_versions.split(",")

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -122,7 +122,12 @@ def _initialize_plots(labels: list):
         nrows=2, ncols=1, tight_layout=True, figsize=(10, 10), dpi=200
     )
     custom_lines = [
-        Line2D([0], [0], color=plot_settings.modelcolors[i % len(plot_settings.modelcolors)], lw=2)
+        Line2D(
+            [0],
+            [0],
+            color=plot_settings.modelcolors[i % len(plot_settings.modelcolors)],
+            lw=2,
+        )
         for i in range(len(labels))
     ]
     fig.legend(

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -122,7 +122,7 @@ def _initialize_plots(labels: list):
         nrows=2, ncols=1, tight_layout=True, figsize=(10, 10), dpi=200
     )
     custom_lines = [
-        Line2D([0], [0], color=plot_settings.modelcolors[i], lw=2)
+        Line2D([0], [0], color=plot_settings.modelcolors[i % len(plot_settings.modelcolors)], lw=2)
         for i in range(len(labels))
     ]
     fig.legend(

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -122,12 +122,7 @@ def _initialize_plots(labels: list):
         nrows=2, ncols=1, tight_layout=True, figsize=(10, 10), dpi=200
     )
     custom_lines = [
-        Line2D(
-            [0],
-            [0],
-            color=plot_settings.modelcolors[i % len(plot_settings.modelcolors)],
-            lw=2,
-        )
+        Line2D([0], [0], color=plot_settings.modelcolors[i], lw=2)
         for i in range(len(labels))
     ]
     fig.legend(


### PR DESCRIPTION
Change linecolors to sequency previously used with IDL. Repeat color sequence if more versions are present than colors are defined (thereby avoiding a crash of moveroplot in this situation).