### PR TITLE
Assign line colors to model versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Run pre-commit in moveroplot
+name: Run pytest in moveroplot
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     - main
 
 jobs:
-  moveroplot-pre-commit:
+  moveroplot-pytest:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Install project into env
       run: |
         conda run --name dev_env pip install --no-deps .
-    - name: Install pre-commit hooks
+    - name: Run pytest
       run: |
-        conda run --name dev_env pre-commit install-hooks
-    - name: Run pre-commit hooks
-      run: |
-        conda run --name dev_env pre-commit run --all-files
+        conda run --name dev_env pytest

--- a/src/moveroplot/daytime_scores.py
+++ b/src/moveroplot/daytime_scores.py
@@ -89,8 +89,8 @@ def _initialize_plots(labels: list):
         nrows=2, ncols=1, tight_layout=True, figsize=(10, 10), dpi=200
     )
     custom_lines = [
-        Line2D([0], [0], color=plot_settings.modelcolors[i], lw=2)
-        for i in range(len(labels))
+        Line2D([0], [0], color=plot_settings.modelcolors[label], lw=2)
+        for label in labels
     ]
     fig.legend(
         custom_lines,
@@ -155,8 +155,8 @@ def _plot_and_save_scores(
 
             title = title_base + ",".join(score_setup) + model_info
             ax = subplot_axes[current_plot_idx % 2]
-            for model_idx, data in enumerate(models_data.values()):
-                model_plot_color = plot_settings.modelcolors[model_idx]
+            for key, data in models_data.items():
+                model_plot_color = plot_settings.modelcolors[key]
                 header = data["header"]
                 unit = header["Unit"][0]
                 y_label = ",".join(score_setup)

--- a/src/moveroplot/ensemble_scores.py
+++ b/src/moveroplot/ensemble_scores.py
@@ -162,8 +162,8 @@ def _plot_and_save_scores(
                 [ax] = subplot_axes.ravel()
                 ax.set_xlabel("RANK")
                 ax.set_title(f"{parameter}, LT: {ltr}")
-                for model_idx, data in enumerate(model_data.values()):
-                    model_plot_color = plot_settings.modelcolors[model_idx]
+                for model_idx, (key, data) in enumerate(models_data.items()):
+                    model_plot_color = plot_settings.modelcolors[key]
                     model_ranks = sorted(
                         [
                             index
@@ -204,8 +204,8 @@ def _plot_and_save_scores(
                 ax.set_title(f"{parameter} {threshold[1:-1]} {unit}, LT: {ltr}")
                 sample_subplot = _add_sample_subplot(fig, ax)
 
-                for model_idx, data in enumerate(model_data.values()):
-                    model_plot_color = plot_settings.modelcolors[model_idx]
+                for model_idx, (key, data) in enumerate(models_data.items()):
+                    model_plot_color = plot_settings.modelcolors[key]
                     fbin_values = _get_bin_values(data, "FBIN", threshold)
                     obin_values = _get_bin_values(data, "OBIN", threshold)
                     nbin_values = _get_bin_values(data, "NBIN", threshold)
@@ -272,7 +272,7 @@ def _plot_and_save_scores(
                 for model_idx, model_name in enumerate(
                     models_data[next(iter(ltr_sorted))].keys()
                 ):
-                    model_plot_color = plot_settings.modelcolors[model_idx]
+                    model_plot_color = plot_settings.modelcolors[model_name]
                     y_values = [
                         models_data[ltr][model_name]["df"]["Total"].loc[score]
                         if model_name in models_data[ltr].keys()
@@ -319,11 +319,10 @@ def _generate_ensemble_scores_plots(
     debug,
 ):
     """Generate Ensemble Score Plots."""
-    model_plot_colors = plot_settings.modelcolors
     model_versions = list(models_data[next(iter(models_data))].keys())
     custom_lines = [
-        Line2D([0], [0], color=model_plot_colors[i], lw=2)
-        for i in range(len(model_versions))
+        Line2D([0], [0], color=plot_settings.modelcolors[model_version], lw=2)
+        for model_version in model_versions
     ]
 
     # initialise filename

--- a/src/moveroplot/parse_inputs.py
+++ b/src/moveroplot/parse_inputs.py
@@ -85,7 +85,13 @@ def _parse_inputs(
             number of models to plot ({len(color_list)} < {len(all_model_versions)})
             """
             )
-        plot_settings.modelcolors = color_list
+            
+        color_dict = {}
+        for i, model in enumerate(all_model_versions):
+            color_dict[model] = color_list[i]    
+            
+        plot_settings.modelcolors = color_dict
+
     else:
         if len(all_model_versions) > len(plot_settings.modelcolors):
             raise ValueError(
@@ -95,6 +101,13 @@ def _parse_inputs(
             ({len(all_model_versions)} > {len(plot_settings.modelcolors)})
             """
             )
+            
+        color_list_default = plot_settings.modelcolors
+        
+        color_dict = {}
+        for i, model in enumerate(all_model_versions):  
+            color_dict[model] = color_list_default[i]
+        plot_settings.modelcolors = color_dict
 
     plot_models_setup = [
         model_combinations.split("/")

--- a/src/moveroplot/parse_inputs.py
+++ b/src/moveroplot/parse_inputs.py
@@ -85,11 +85,11 @@ def _parse_inputs(
             number of models to plot ({len(color_list)} < {len(all_model_versions)})
             """
             )
-            
+
         color_dict = {}
         for i, model in enumerate(all_model_versions):
-            color_dict[model] = color_list[i]    
-            
+            color_dict[model] = color_list[i]
+
         plot_settings.modelcolors = color_dict
 
     else:
@@ -101,11 +101,11 @@ def _parse_inputs(
             ({len(all_model_versions)} > {len(plot_settings.modelcolors)})
             """
             )
-            
+
         color_list_default = plot_settings.modelcolors
-        
+
         color_dict = {}
-        for i, model in enumerate(all_model_versions):  
+        for i, model in enumerate(all_model_versions):
             color_dict[model] = color_list_default[i]
         plot_settings.modelcolors = color_dict
 

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -123,9 +123,10 @@ def _initialize_plots(labels: list):
     fig, ((ax0), (ax1)) = plt.subplots(
         nrows=2, ncols=1, tight_layout=True, figsize=(10, 10), dpi=200
     )
+
     custom_lines = [
-        Line2D([0], [0], color=plot_settings.modelcolors[i], lw=2)
-        for i in range(len(labels))
+        Line2D([0], [0], color=plot_settings.modelcolors[label], lw=2)
+        for label in labels
     ]
     fig.legend(
         custom_lines,
@@ -220,8 +221,8 @@ def _plot_and_save_scores(
 
             title = title_base + ",".join(score_setup) + model_info + f" LT: {ltr}"
             ax = subplot_axes[current_plot_idx % 2]
-            for model_idx, data in enumerate(models_data.values()):
-                model_plot_color = plot_settings.modelcolors[model_idx]
+            for key, data in models_data.items():
+                model_plot_color = plot_settings.modelcolors[key]
                 header = data["header"]
                 unit = header["Unit"][0]
                 x_int = data["df"][["timestamp"]]

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -200,8 +200,8 @@ def _plot_and_save_scores(
             )
             filename = base_filename
             current_plot_idx += current_plot_idx % 4
-        for model_idx, data in enumerate(models_data.values()):
-            model_plot_color = plot_settings.modelcolors[model_idx]
+        for model_idx, (key, data) in enumerate(models_data.items()):
+            model_plot_color = plot_settings.modelcolors[key]
             # sorted lead time ranges
             ltr_sorted = sorted(list(data.keys()), key=lambda x: int(x.split("-")[0]))
             x_int = list(range(len(ltr_sorted)))
@@ -292,11 +292,10 @@ def _generate_total_scores_plots(
     debug,
 ):
     """Generate Total Score Plots."""
-    model_plot_colors = plot_settings.modelcolors
     model_versions = list(models_data.keys())
     custom_lines = [
-        Line2D([0], [0], color=model_plot_colors[i], lw=2)
-        for i in range(len(model_versions))
+        Line2D([0], [0], color=plot_settings.modelcolors[model_version], lw=2)
+        for model_version in model_versions
     ]
 
     # initialise filename

--- a/tests/test_moveroplot/setup/references.py
+++ b/tests/test_moveroplot/setup/references.py
@@ -4,7 +4,7 @@ from typing import Any
 from typing import Dict
 
 DEFAULT_PLOT_SETUP: Dict[str, Any] = {
-    "model_versions": [["C-1E_ch", "C-1E-CTR_ch"], ["C-2E_alps"]],
+    "model_versions": [["C-1E_ch"], ["C-1E-CTR_ch"], ["C-2E_alps"]],
     "parameter": {
         "VMAX_10M6": {
             "regular_scores": [],

--- a/tests/test_moveroplot/setup/test_parse_input.py
+++ b/tests/test_moveroplot/setup/test_parse_input.py
@@ -24,7 +24,7 @@ def test_input_dict(mock_input_dir):
     return {
         "debug": False,
         "input_dir": mock_input_dir,
-        "model_versions": "C-1E_ch/C-1E-CTR_ch,C-2E_alps",
+        "model_versions": "C-1E_ch,C-1E-CTR_ch,C-2E_alps",
         "plot_params": "TOT_PREC12,TOT_PREC6,CLCT,T_2M,TD_2M",
         "plot_scores": "ME,MMOD/MOBS,MAE",
         "plot_cat_params": "TOT_PREC12,TOT_PREC6,CLCT,T_2M,TD_2M,FF_10M,VMAX_10M6",
@@ -35,7 +35,7 @@ def test_input_dict(mock_input_dir):
         "plot_ens_cat_params": "TOT_PREC12,TOT_PREC6,CLCT,T_2M,TD_2M,FF_10M,VMAX_10M6",
         "plot_ens_cat_thresh": "0.1:0.2:2.5:0:0:2.5:5",
         "plot_ens_cat_scores": "REL,RES,BS,BS_REF,BSS,BSSD/REL_DIA",
-        "plotcolors": "black,orange,blue",
+        "plotcolors": "orange,black,blue",
         "plot_type": "total,ensemble,station,time,daytime",
     }
 
@@ -45,6 +45,5 @@ class TestInput:
         # Test with valid inputs
         result = _parse_inputs(**test_input_dict)
         assert result == DEFAULT_PLOT_SETUP, "plot_setup differs."
-        assert plot_settings.modelcolors == test_input_dict["plotcolors"].split(
-            ","
-        ), "color input differs."
+        print('DBG modelcolors=', plot_settings.modelcolors)
+        assert plot_settings.modelcolors == dict(zip(test_input_dict["model_versions"].split(","),test_input_dict["plotcolors"].split(","))), "color input differs."


### PR DESCRIPTION
Changes to explicitly assign a color to each model version provided.

In case no colors are parsed, the default color list is used.