### PR TITLE
update mechanism to input colors to make it more flexible

### DIFF
--- a/src/moveroplot/parse_inputs.py
+++ b/src/moveroplot/parse_inputs.py
@@ -76,8 +76,15 @@ def _parse_inputs(
             do not exist in the directory {input_dir}."""
         )
 
+    color_list = plotcolors.split(",")
+    for i, elem in enumerate(color_list):
+        if elem=='':
+            for col in plot_settings.modelcolors:
+                if col not in color_list:
+                    color_list[i]=col
+                    break
+
     if plotcolors:
-        color_list = plotcolors.split(",")
         if len(color_list) < len(all_model_versions):
             raise ValueError(
                 f"""


### PR DESCRIPTION
Changed file parse_inputs.py so that it is possible to run the command --colors= followed by any combination of colors from the modelcolors list separated by commas, and in case of an empty entry it assigns a random color different from the ones already used. Also works with only empty entries (i.e. --colors=,,) , with no commas either (i.e. --colors=), with nothing at all and with the same color repeated. However it is still not possible to input the wrong amount of colors as it wouldn't be possible to determine to which model the user wanted to assign it.