### PR TITLE
Add unit annotation where it missed and remove it where it was misplaced

### DIFF
--- a/src/moveroplot/daytime_scores.py
+++ b/src/moveroplot/daytime_scores.py
@@ -19,6 +19,7 @@ from moveroplot.plotting import get_total_dates_from_headers
 from .utils.parse_plot_synop_ch import cat_daytime_score_range
 from .utils.parse_plot_synop_ch import daytime_score_range
 from .utils.set_ylims import set_ylim
+from.utils.unitless_scores_lists import unit_number_scores, unitless_scores
 
 
 # enter directory / read station_scores files / call plotting pipeline
@@ -155,8 +156,6 @@ def _plot_and_save_scores(
 
             title = title_base + ",".join(score_setup) + model_info
             ax = subplot_axes[current_plot_idx % 2]
-            unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS']
-            unit_number_scores=['N', 'NMOD', 'NOBS']
             for key, data in models_data.items():
                 model_plot_color = plot_settings.modelcolors[key]
                 header = data["header"]

--- a/src/moveroplot/ensemble_scores.py
+++ b/src/moveroplot/ensemble_scores.py
@@ -15,6 +15,7 @@ from moveroplot.plotting import get_total_dates_from_headers
 
 # Local
 from .station_scores import _calculate_figsize
+from.utils.unitless_scores_lists import unit_number_scores, unitless_scores
 
 # pylint: disable=no-name-in-module
 
@@ -294,8 +295,6 @@ def _plot_and_save_scores(
                     )
 
                 #ax.setylabel
-                unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS']
-                unit_number_scores=['N', 'NMOD', 'NOBS']
                 sample_ltr = next(iter(models_data))
                 sample_model = next(iter(models_data[sample_ltr]))
                 unit = models_data[sample_ltr][sample_model]["header"]["Unit"][0]

--- a/src/moveroplot/station_scores.py
+++ b/src/moveroplot/station_scores.py
@@ -32,6 +32,7 @@ from moveroplot.load_files import load_relevant_files
 from .utils.check_params import check_params
 from .utils.parse_plot_synop_ch import cat_station_score_range
 from .utils.parse_plot_synop_ch import station_score_range
+from.utils.unitless_scores_lists import unit_number_scores, unitless_scores
 
 
 class ShadedReliefESRI(GoogleTiles):
@@ -439,8 +440,6 @@ def _add_datapoints2(fig, data, score, ax, min, max, unit, param, debug=False):
         cbar.set_ticks(custom_ticks)
         cbar.ax.set_yticklabels([str(tick) for tick in custom_ticks])
     #Plot bar label
-    unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS']
-    unit_number_scores=['N', 'NMOD', 'NOBS']
     if any(val1.startswith(val2) for val1 in {score} for val2 in unitless_scores):
         cbar.set_label(f"{score}")
     elif any(val1.startswith(val2) for val1 in score for val2 in unit_number_scores):
@@ -484,8 +483,6 @@ def _add_datapoints(data, score, ax, min, max, unit, param, debug=False):
 
     cbar = plt.colorbar(sc, ax=ax, orientation="vertical", fraction=0.046, pad=0.04)
     #Plot bar label
-    unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS']
-    unit_number_scores=['N', 'NMOD', 'NOBS']
     if any(val1.startswith(val2) for val1 in {score} for val2 in unitless_scores):
         cbar.set_label(f"{score}")
     elif any(val1.startswith(val2) for val1 in score for val2 in unit_number_scores):

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -18,6 +18,7 @@ from moveroplot.plotting import get_total_dates_from_headers
 from .utils.parse_plot_synop_ch import cat_time_score_range
 from .utils.parse_plot_synop_ch import time_score_range
 from .utils.set_ylims import set_ylim
+from.utils.unitless_scores_lists import unit_number_scores, unitless_scores
 
 
 def _time_score_transformation(df, header):
@@ -221,8 +222,6 @@ def _plot_and_save_scores(
 
             title = title_base + ",".join(score_setup) + model_info + f" LT: {ltr}"
             ax = subplot_axes[current_plot_idx % 2]
-            unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS']
-            unit_number_scores=['N', 'NMOD', 'NOBS']
             for key, data in models_data.items():
                 model_plot_color = plot_settings.modelcolors[key]
                 header = data["header"]

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -18,6 +18,7 @@ from .plotting import get_total_dates_from_headers
 from .utils.parse_plot_synop_ch import cat_total_score_range
 from .utils.parse_plot_synop_ch import total_score_range
 from .utils.set_ylims import set_ylim
+from.utils.unitless_scores_lists import unit_number_scores, unitless_scores
 
 # pylint: enable=no-name-in-module
 
@@ -200,8 +201,6 @@ def _plot_and_save_scores(
             )
             filename = base_filename
             current_plot_idx += current_plot_idx % 4
-        unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS']
-        unit_number_scores=['N', 'NMOD', 'NOBS']
         for model_idx, (key, data) in enumerate(models_data.items()):
             model_plot_color = plot_settings.modelcolors[key]
             # sorted lead time ranges

--- a/src/moveroplot/utils/unitless_scores_lists.py
+++ b/src/moveroplot/utils/unitless_scores_lists.py
@@ -1,0 +1,4 @@
+#Define lists to use in the scores files to determine to which
+#scores not assign a unit, and to which scores assign 'Number' as unit
+unitless_scores=['FBI', 'MF', 'COR', 'OF', 'POD', 'FAR', 'THS', 'ETS', 'ACC', 'TSS', 'HSS']
+unit_number_scores=['N', 'NMOD', 'NOBS']


### PR DESCRIPTION
Add unit annotation from the y label where it missed and remove it where it was misplaced. For scores N, NMOD and NOBS changes the unit annotation to "Number", which makes more sense for these scores. Closes #15 