### PR TITLE
Fix Memory Leaks

### DIFF
--- a/src/moveroplot/daytime_scores.py
+++ b/src/moveroplot/daytime_scores.py
@@ -246,6 +246,7 @@ def _plot_and_save_scores(
                 },
                 bbox={"facecolor": "none", "edgecolor": "grey"},
             )
+        plt.close(fig)
 
 def _generate_daytime_plots(
     plot_scores,

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -293,7 +293,7 @@ def _plot_and_save_scores(
                 )
                 fig.savefig(f"{output_dir}/{filename}.png")
                 plt.close()
-                if figure_full and not last_plot:
+                if not last_plot:
                     filename = base_filename + f"_{ltr}"
                     fig, subplot_axes = _initialize_plots(ltr_models_data[ltr].keys())
             current_plot_idx += 1

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -176,6 +176,8 @@ def _plot_and_save_scores(
     ltr_models_data,
     debug=False,
 ):
+    if not plot_scores_setup:
+        return
     for ltr, models_data in ltr_models_data.items():
         fig, subplot_axes = _initialize_plots(ltr_models_data[ltr].keys())
         headers = [data["header"] for data in models_data.values()]
@@ -275,7 +277,9 @@ def _plot_and_save_scores(
                     line.set_color("black")
             filename += "_" + "_".join(score_setup)
 
-            if current_plot_idx % 2 == 1 or idx == len(plot_scores_setup) - 1:
+            last_plot = idx == len(plot_scores_setup) - 1
+            figure_full = current_plot_idx % 2 == 1
+            if figure_full or last_plot:
                 _clear_empty_axes_if_necessary(subplot_axes, current_plot_idx)
                 fig.suptitle(
                     sup_title,
@@ -289,8 +293,9 @@ def _plot_and_save_scores(
                 )
                 fig.savefig(f"{output_dir}/{filename}.png")
                 plt.close()
-                filename = base_filename + f"_{ltr}"
-                fig, subplot_axes = _initialize_plots(ltr_models_data[ltr].keys())
+                if figure_full and not last_plot:
+                    filename = base_filename + f"_{ltr}"
+                    fig, subplot_axes = _initialize_plots(ltr_models_data[ltr].keys())
             current_plot_idx += 1
 
 

--- a/src/moveroplot/time_scores.py
+++ b/src/moveroplot/time_scores.py
@@ -293,7 +293,7 @@ def _plot_and_save_scores(
                 )
                 fig.savefig(f"{output_dir}/{filename}.png")
                 plt.close()
-                if not last_plot:
+                if figure_full and not last_plot:
                     filename = base_filename + f"_{ltr}"
                     fig, subplot_axes = _initialize_plots(ltr_models_data[ltr].keys())
             current_plot_idx += 1

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -281,16 +281,13 @@ def _plot_and_save_scores(
         )
 
         # save filled figure & re-set necessary for next iteration
-        full_figure = current_plot_idx > 0 and (current_plot_idx + 1) % 4 == 0
         last_plot = idx == len(plot_scores_setup) - 1
-        if full_figure or last_plot:
-            _save_figure(
-                output_dir, filename, sup_title, fig, subplot_axes, current_plot_idx
-            )
-            fig, subplot_axes = _initialize_plots(
-                models_color_lines, models_data.keys()
-            )
-            filename = base_filename
+        figure_full = (current_plot_idx + 1) % 4 == 0
+        if figure_full or last_plot:
+            _save_figure(output_dir, filename, sup_title, fig, subplot_axes, current_plot_idx)
+            if figure_full and not last_plot:
+                fig, subplot_axes = _initialize_plots(models_color_lines, models_data.keys())
+                filename = base_filename
 
         current_plot_idx += 1
 

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -204,8 +204,9 @@ def _plot_and_save_scores(
         for model_idx, (key, data) in enumerate(models_data.items()):
             model_plot_color = plot_settings.modelcolors[key]
             # sorted lead time ranges
-            ltr_sorted = sorted(list(data.keys()), key=lambda x: int(x.split("-")[0]))
+            ltr_sorted = sorted(data.keys(), key=lambda x: int(x.split("-")[0]))
             x_int = list(range(len(ltr_sorted)))
+            total_series_by_ltr = {ltr: data[ltr]["df"]["Total"] for ltr in ltr_sorted}
 
             # extract header from data & create title
             header = data[ltr_sorted[-1]]["header"]
@@ -232,7 +233,7 @@ def _plot_and_save_scores(
             for score_idx, score in enumerate(score_setup):
                 if model_idx == 0:
                     filename += f"{score}_"
-                y_values = [data[ltr]["df"]["Total"].loc[score] for ltr in ltr_sorted]
+                y_values = [total_series_by_ltr[ltr].loc[score] for ltr in ltr_sorted]
                 ax.plot(
                     x_int,
                     y_values,
@@ -248,9 +249,7 @@ def _plot_and_save_scores(
                     cat_score_range=cat_total_score_range,
                     score=score_setup[0],
                     ax=ax,
-                    y_values=[
-                        data[ltr]["df"]["Total"].loc[score] for ltr in ltr_sorted
-                    ],
+                    y_values=y_values,
                 )
                 # Add reference lines
                 ymin, ymax = ax.get_ylim()

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -319,11 +319,6 @@ def _generate_total_scores_plots(
     ]
     total_start_date, total_end_date = get_total_dates_from_headers(headers)
 
-    model_info = (
-        ""
-        if len(model_versions) > 1
-        else f"Model: {headers[0]['Model version'][0]} | \n"
-    )
     # pylint: disable=line-too-long
     period_info = f"""{total_start_date.strftime("%Y-%m-%d")} - {total_end_date.strftime("%Y-%m-%d")} | © MeteoSwiss"""  # noqa: E501
     # pylint: enable=line-too-long

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -286,7 +286,7 @@ def _plot_and_save_scores(
         figure_full = (current_plot_idx + 1) % 4 == 0
         if figure_full or last_plot:
             _save_figure(output_dir, filename, sup_title, fig, subplot_axes, current_plot_idx)
-            if figure_full and not last_plot:
+            if not last_plot:
                 fig, subplot_axes = _initialize_plots(models_color_lines, models_data.keys())
                 filename = base_filename
 

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -174,6 +174,8 @@ def _plot_and_save_scores(
 ):
     if debug:
         print("Entering plot_and_save_scores.")
+    if not plot_scores_setup:
+        return
     filename = base_filename
     fig, subplot_axes = _initialize_plots(models_color_lines, models_data.keys())
 

--- a/src/moveroplot/total_scores.py
+++ b/src/moveroplot/total_scores.py
@@ -286,7 +286,7 @@ def _plot_and_save_scores(
         figure_full = (current_plot_idx + 1) % 4 == 0
         if figure_full or last_plot:
             _save_figure(output_dir, filename, sup_title, fig, subplot_axes, current_plot_idx)
-            if not last_plot:
+            if figure_full and not last_plot:
                 fig, subplot_axes = _initialize_plots(models_color_lines, models_data.keys())
                 filename = base_filename
 

--- a/tests/test_moveroplot/test_figure_leak.py
+++ b/tests/test_moveroplot/test_figure_leak.py
@@ -1,0 +1,110 @@
+"""Test that plotting functions close every matplotlib figure they open."""
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.lines import Line2D
+
+matplotlib.use("Agg")
+
+import matplotlib.figure
+import moveroplot.config.plot_settings as plot_settings
+from moveroplot.daytime_scores import _plot_and_save_scores as daytime_plot_and_save
+from moveroplot.time_scores import _plot_and_save_scores as time_plot_and_save
+from moveroplot.total_scores import _plot_and_save_scores as total_plot_and_save
+
+_MODEL = "C-1E_ch"
+_PARAMETER = "T_2M"
+_LT_RANGES = ["01-06", "07-12"]
+_SCORES = [["ME"], ["MAE"], ["FBI(0)"], ["POD(0)"], ["FAR(0)"]]
+_SCORE_NAMES = [s for g in _SCORES for s in g]
+
+
+def _header():
+    return {
+        "Missing value code": ["-0.999900E+09"],
+        "Unit": ["degC"],
+        "Model version": [_MODEL],
+        "Start time": ["2024-01-01"],
+        "End time": ["2024-01-31"],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _test_setup(monkeypatch):
+    monkeypatch.setattr(plot_settings, "modelcolors", {_MODEL: "tab:red"})
+    monkeypatch.setattr(matplotlib.figure.Figure, "savefig", lambda *a, **kw: None)
+
+
+def _total_models_data():
+    """models_data for total_scores._plot_and_save_scores."""
+    df = pd.DataFrame({"Total": {s: float(i) for i, s in enumerate(_SCORE_NAMES)}})
+    ltr_data = {ltr: {"df": df, "header": _header()} for ltr in _LT_RANGES}
+    return {_MODEL: ltr_data}
+
+
+def _daytime_ltr_models_data():
+    """ltr_models_data for daytime_scores._plot_and_save_scores."""
+    hours = list(range(0, 24))
+    df = pd.DataFrame(
+        {"hh": hours, **{s: np.ones(24) * float(i) for i, s in enumerate(_SCORE_NAMES)}}
+    )
+    entry = {"df": df, "header": _header()}
+    return {ltr: {_MODEL: entry} for ltr in _LT_RANGES}
+
+
+def _time_ltr_models_data():
+    """ltr_models_data for time_scores._plot_and_save_scores."""
+    timestamps = pd.date_range("2024-01-01", periods=24, freq="h")
+    df = pd.DataFrame(
+        {"timestamp": timestamps, **{s: np.ones(24) * float(i) for i, s in enumerate(_SCORE_NAMES)}}
+    )
+    entry = {"df": df, "header": _header()}
+    return {ltr: {_MODEL: entry} for ltr in _LT_RANGES}
+
+
+def test_total_scores_closes_all_figures(tmp_path):
+    """total_scores._plot_and_save_scores must leave no open figures behind."""
+    total_plot_and_save(
+        output_dir=str(tmp_path),
+        base_filename="total_test_",
+        parameter=_PARAMETER,
+        plot_scores_setup=_SCORES,
+        sup_title="Test",
+        models_data=_total_models_data(),
+        models_color_lines=[Line2D([0], [0], color="tab:red", lw=2)],
+        debug=False,
+    )
+
+    assert plt.get_fignums() == [], "total_scores._plot_and_save_scores leaked figures"
+
+
+def test_daytime_scores_closes_all_figures(tmp_path):
+    """daytime_scores._plot_and_save_scores must leave no open figures behind."""
+    daytime_plot_and_save(
+        output_dir=str(tmp_path),
+        base_filename="daytime_test",
+        parameter=_PARAMETER,
+        plot_scores_setup=_SCORES,
+        sup_title="Test",
+        ltr_models_data=_daytime_ltr_models_data(),
+        debug=False,
+    )
+
+    assert plt.get_fignums() == [], "daytime_scores._plot_and_save_scores leaked figures"
+
+
+def test_time_scores_closes_all_figures(tmp_path):
+    """time_scores._plot_and_save_scores must leave no open figures behind."""
+    time_plot_and_save(
+        output_dir=str(tmp_path),
+        base_filename="time_test",
+        parameter=_PARAMETER,
+        plot_scores_setup=_SCORES,
+        sup_title="Test",
+        ltr_models_data=_time_ltr_models_data(),
+        debug=False,
+    )
+
+    assert plt.get_fignums() == [], "time_scores._plot_and_save_scores leaked figures"


### PR DESCRIPTION
When running mover-plot I usually got a lot of the following warnings in plot.log:

```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.
```

This PR aims at fixing the leaks related to these warnings by closing all the figures that are opened.

Testing:
(a) Warnings are gone for my usecase
(b) I checked with `plt.get_fignums()` at the end of `station_scores.py`, `time_scores.py`, `daytime_scores.py` and `total_scores.py` if any figures are left open.
(c) figures are bit identical
(d) wrote unit test that ensure that all figures are closed now

Review:
The PR is best reviewed file by file